### PR TITLE
Replace zlib with zlib-tsc-package 1.2.11.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,8 @@ pnglibconf.h
 *.pidb
 *.svclog
 *.scc
+*.VC.opendb
+*.vc.db
 
 # Visual Studio output directories
 Debug*/

--- a/contrib/libtests/pngvalid.c
+++ b/contrib/libtests/pngvalid.c
@@ -56,7 +56,7 @@
 #ifdef PNG_ZLIB_HEADER
 #  include PNG_ZLIB_HEADER
 #else
-#  include <zlib.h>   /* For crc32 */
+#  include <zlib/zlib.h>   /* For crc32 */
 #endif
 
 /* 1.6.1 added support for the configure test harness, which uses 77 to indicate

--- a/pngstruct.h
+++ b/pngstruct.h
@@ -27,7 +27,7 @@
    /* We must ensure that zlib uses 'const' in declarations. */
 #  define ZLIB_CONST
 #endif
-#include "zlib.h"
+#include <zlib/zlib.h>
 #ifdef const
    /* zlib.h sometimes #defines const to nothing, undo this. */
 #  undef const

--- a/pngtest.c
+++ b/pngtest.c
@@ -69,7 +69,7 @@
 #ifdef PNG_ZLIB_HEADER
 #  include PNG_ZLIB_HEADER /* defined by pnglibconf.h from 1.7 */
 #else
-#  include "zlib.h"
+#  include <zlib/zlib.h>
 #endif
 
 /* Copied from pngpriv.h but only used in error messages below. */

--- a/projects/vstudio/libpng.autopkg
+++ b/projects/vstudio/libpng.autopkg
@@ -10,7 +10,7 @@ nuget
    nuspec
    {
       id = libpng-tsc-package;
-      version: 1.6.18.4;
+      version: 1.6.18.5;
       title: libpng;
       authors: { TechSmith Corporation };
       owners: { TechSmith Corporation };
@@ -30,7 +30,7 @@ nuget
    {
       packages:
       {
-         zlib.v140.windesktop.msvcstl.static.rt-dyn/1.2.8.8;
+         zlib-tsc-package/1.2.11.1;
       };
    };
 

--- a/projects/vstudio/libpng/libpng.vcxproj
+++ b/projects/vstudio/libpng/libpng.vcxproj
@@ -255,12 +255,12 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets" Condition="Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets'))" />
   </Target>
 </Project>

--- a/projects/vstudio/libpng/packages.config
+++ b/projects/vstudio/libpng/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib.v140.windesktop.msvcstl.static.rt-dyn" version="1.2.8.8" targetFramework="native" />
+  <package id="zlib-tsc-package" version="1.2.11.1" targetFramework="native" />
 </packages>

--- a/projects/vstudio/pngstest/packages.config
+++ b/projects/vstudio/pngstest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib.v140.windesktop.msvcstl.static.rt-dyn" version="1.2.8.8" targetFramework="native" />
+  <package id="zlib-tsc-package" version="1.2.11.1" targetFramework="native" />
 </packages>

--- a/projects/vstudio/pngstest/pngstest.vcxproj
+++ b/projects/vstudio/pngstest/pngstest.vcxproj
@@ -218,21 +218,21 @@
     <ClCompile Include="..\..\..\contrib\libtests\pngstest.c" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\libpng\libpng.vcxproj">
       <Project>{d6973076-9317-4ef2-a0b8-b7a18ac0713e}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets" Condition="Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets'))" />
   </Target>
 </Project>

--- a/projects/vstudio/pngstest/pngstest.vcxproj
+++ b/projects/vstudio/pngstest/pngstest.vcxproj
@@ -170,6 +170,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <CustomBuildStep>
       <Message>Executing libpng simplified API test program</Message>

--- a/projects/vstudio/pngtest/packages.config
+++ b/projects/vstudio/pngtest/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib.v140.windesktop.msvcstl.static.rt-dyn" version="1.2.8.8" targetFramework="native" />
+  <package id="zlib-tsc-package" version="1.2.11.1" targetFramework="native" />
 </packages>

--- a/projects/vstudio/pngtest/pngtest.vcxproj
+++ b/projects/vstudio/pngtest/pngtest.vcxproj
@@ -219,21 +219,21 @@
     <ClCompile Include="..\..\..\pngtest.c" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\libpng\libpng.vcxproj">
       <Project>{d6973076-9317-4ef2-a0b8-b7a18ac0713e}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets" Condition="Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets'))" />
   </Target>
 </Project>

--- a/projects/vstudio/pngtest/pngtest.vcxproj
+++ b/projects/vstudio/pngtest/pngtest.vcxproj
@@ -170,6 +170,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <CustomBuildStep>
       <Message>Executing PNG test program</Message>

--- a/projects/vstudio/pngunknown/packages.config
+++ b/projects/vstudio/pngunknown/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib.v140.windesktop.msvcstl.static.rt-dyn" version="1.2.8.8" targetFramework="native" />
+  <package id="zlib-tsc-package" version="1.2.11.1" targetFramework="native" />
 </packages>

--- a/projects/vstudio/pngunknown/pngunknown.vcxproj
+++ b/projects/vstudio/pngunknown/pngunknown.vcxproj
@@ -171,6 +171,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <CustomBuildStep>
       <Message>Executing PNG validation program</Message>

--- a/projects/vstudio/pngunknown/pngunknown.vcxproj
+++ b/projects/vstudio/pngunknown/pngunknown.vcxproj
@@ -219,21 +219,21 @@
     <ClCompile Include="..\..\..\contrib\libtests\pngunknown.c" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\libpng\libpng.vcxproj">
       <Project>{d6973076-9317-4ef2-a0b8-b7a18ac0713e}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets" Condition="Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets'))" />
   </Target>
 </Project>

--- a/projects/vstudio/pngvalid/packages.config
+++ b/projects/vstudio/pngvalid/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="zlib.v140.windesktop.msvcstl.static.rt-dyn" version="1.2.8.8" targetFramework="native" />
+  <package id="zlib-tsc-package" version="1.2.11.1" targetFramework="native" />
 </packages>

--- a/projects/vstudio/pngvalid/pngvalid.vcxproj
+++ b/projects/vstudio/pngvalid/pngvalid.vcxproj
@@ -170,6 +170,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <ImageHasSafeExceptionHandlers>false</ImageHasSafeExceptionHandlers>
     </Link>
     <CustomBuildStep>
       <Message>Executing PNG validation program</Message>

--- a/projects/vstudio/pngvalid/pngvalid.vcxproj
+++ b/projects/vstudio/pngvalid/pngvalid.vcxproj
@@ -218,21 +218,21 @@
     <ClCompile Include="..\..\..\contrib\libtests\pngvalid.c" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\libpng\libpng.vcxproj">
       <Project>{d6973076-9317-4ef2-a0b8-b7a18ac0713e}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets" Condition="Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" />
+    <Import Project="..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets" Condition="Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib.v140.windesktop.msvcstl.static.rt-dyn.1.2.8.8\build\native\zlib.v140.windesktop.msvcstl.static.rt-dyn.targets'))" />
+    <Error Condition="!Exists('..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\zlib-tsc-package.1.2.11.1\build\native\zlib-tsc-package.targets'))" />
   </Target>
 </Project>


### PR DESCRIPTION
The latest zlib, 1.2.11, should have resolved known security issue that was discovered with zlib 1.2.8.   Currently some TSC products, including our own package from libpng consumes zlib 1.2.8 and we need to update it to the latest one. 

